### PR TITLE
Excluding stream_eta axiom

### DIFF
--- a/congruence.v
+++ b/congruence.v
@@ -100,7 +100,7 @@ inversion H2.
 constructor 1. apply C_always3. apply H1.
 (*apply H.
 rewrite H3; assumption.*)
-intros s str H_P H_rec H_implies.
+intros (*s*) str H_P H_rec H_implies.
 constructor 2.
 apply H_rec.
 inversion_clear H_implies.
@@ -211,7 +211,7 @@ constructor 1.
 inversion Himplie.
 apply C_always3. auto.
 (*rewrite H1; auto.*)
-intros s str HP Huntil H_rec HIP HIQ.
+intros (*s*) str HP Huntil H_rec HIP HIQ.
 constructor 2.
 inversion HIP; auto.
 apply H_rec.

--- a/leads_to.v
+++ b/leads_to.v
@@ -52,8 +52,8 @@ rewrite H1 in H; rewrite H1.
 *)
 elim (C_always3 H_C); clear C_always3 C_always4 (*H1 s0 str0*) H_always H_C str.
 intros str E_str; constructor 1; assumption.
-intros s str D_str until_D_E until_or; constructor 2; auto.
-intros s str B_str until_B_C H_always_until H_always; constructor 2; auto.
+intros (*s*) str D_str until_D_E until_or; constructor 2; auto.
+intros (*s*) str B_str until_B_C H_always_until H_always; constructor 2; auto.
 apply H_always_until; inversion H_always; assumption.
 Qed.
 

--- a/liveness.v
+++ b/liveness.v
@@ -79,9 +79,9 @@ intros P dec str H_followed; elim (dec str).
 intro P_str; unfold is_followed in H_followed.
 generalize P_str; generalize H_followed; simple induction 1; try assumption.
 intros str' not_P_str' P_str'; absurd (P str'); assumption.
-intros s str' ev_P_str' H_P_until P_str'.
+intros (*s*) str' ev_P_str' H_P_until P_str'.
 constructor 2; try assumption.
-elim (dec str'); intro Pstr'.
+elim (dec (tln str')); intro Pstr'.
 apply H_P_until. assumption.
 constructor 1; assumption.
 constructor 1; assumption.
@@ -95,8 +95,8 @@ Lemma eventually_until :
 
 intros P str dec; simple induction 1; clear H str.
 intros str H_P; constructor 1; assumption.
-intros s str H_ev H_until.
-elim (dec {| hdn := s; tln := str|}). intro H_P.
+intros (*s*) str H_ev H_until.
+elim (dec str). intro H_P.
   - constructor 1. assumption.
   - constructor 2; assumption.
 Qed.
@@ -123,21 +123,21 @@ elim C_always3; clear C_always3.
 
 (*clear s0 str0;*)clear str. intro str. (*case str. 
 clear str;*) intros (*s str*) H_fair H_trace H_P.
-  - rewrite -> stream_eta. constructor 2.
-      -- rewrite <- stream_eta. assumption.
+  - constructor 2. (*rewrite -> stream_eta. constructor 2.*)
+      -- assumption. (*rewrite <- stream_eta. assumption.*)
       -- constructor 1. unfold state2stream_formula in |-*. apply leads_P_Q with (s := hdn str).
           --- auto.
           --- elim H_fair. intros a fair_a H_trans. clear fair_a.
                 ---- apply C_trans with (a := a). auto.
                 ---- apply H_enabled. auto.
   - unfold state2stream_formula in |- *; simpl in |- *.
-    intros s1 str1 H_ind H1 H_trace H_P.
+    intros (*s1*) str1 H_ind H1 H_trace H_P.
     inversion_clear H_trace.
     inversion C_always3.
       -- constructor 2.
           --- auto.
-          --- apply H1; auto. simpl in H. rewrite <- H. assumption.
-      -- simpl in H. constructor 2; auto. constructor 1. apply leads_P_Q with (s := s1); assumption.
+          --- apply H1; auto. simpl in H0. rewrite <- H0. assumption.
+      -- simpl in H. constructor 2; auto. constructor 1. apply leads_P_Q with (s := hdn str1); assumption.
 Qed.
 
 

--- a/ltl.v
+++ b/ltl.v
@@ -49,7 +49,7 @@ Inductive none_or_one_step (s : state) : state -> Prop :=
 
 CoInductive stream : Set := Conn {hdn : state; tln : stream}.
 
-Axiom stream_eta : forall str : stream, str = Conn (hdn str) (tln str).
+(*Axiom stream_eta : forall str : stream, str = Conn (hdn str) (tln str).*)
 
 (*Definition head_str (str : stream) : state :=
   match str with
@@ -101,32 +101,33 @@ Definition trace : stream -> Prop :=
 Definition run (str : stream) : Prop :=
   init_state (hdn str) /\ trace str.
 
-
+(*
 Inductive eventually (P : stream_formula) : stream -> Prop :=
   | ev_h : forall str : stream, P str -> eventually P str
   | ev_t :
       forall (s : state) (str : stream),
       eventually P str -> eventually P (Conn s str).
-(*
+*)
+
 Inductive eventually (P : stream_formula) : stream -> Prop :=
   | ev_h : forall str : stream, P str -> eventually P str
   | ev_t : 
       forall (str : stream),
       eventually P (tln str) -> eventually P str.
-*)
-
+(*
 Inductive until (P Q : stream_formula) : stream -> Prop :=
   | until_h : forall str : stream, Q str -> until P Q str
   | until_t :
       forall (s : state) (str : stream),
       P (Conn s str) -> until P Q str -> until P Q (Conn s str).
-(*
+*)
+
 Inductive until (P Q : stream_formula) : stream -> Prop :=
   | until_h : forall str : stream, Q str -> until P Q str
   | until_t : 
       forall (str : stream),
       P str -> until P Q (tln str) -> until P Q str.
-*)
+
 CoInductive unless (P Q : stream_formula) (str : stream) : Prop :=
   { unless' : (Q str) \/ (P str -> unless P Q (tln str))}.
 

--- a/termination.v
+++ b/termination.v
@@ -77,7 +77,7 @@ intros v H; elim H; clear H.
 intros H_meas H_r; apply H_rec with (y := v); auto.
 constructor 1; auto.
 clear H_rec H_acc H_wf H A_head H_meas H_until str.
-intros s str H_B H_until H_rec H_always.
+intros (*s*) str H_B H_until H_rec H_always.
 constructor 2; auto.
 apply H_rec.
 intro v.
@@ -89,7 +89,7 @@ intro v.
         (state2stream_formula
            (fun s : state =>
             A s /\ (exists t : Alpha, meas s t /\ r t v) \/ C s)) str)
-     (Conn s str)); auto. 
+     str); auto. 
 clear H_always. intro H_always. inversion H_always. assumption.
 simpl in C_always4; inversion C_always4. (*rewrite H2;*) generalize C_always5.
  (*replace str0 with (tl_str str);*) auto.


### PR DESCRIPTION
Changed inductive definitions of until and eventually to "destruct" instead of "construct" style.

This makes the proofs possible without stream_eta quality axiom. Also changed these proofs to no longer use this axiom.